### PR TITLE
ENG-1700: Add support for Logstash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ ArcadiaLogger.setup do |config|
   config.adapters = {
     custom_logger: ArcadiaLogger::Adapters::Logger.new # STDOUT by default,
     rails_application_logger: ArcadiaLogger::Adapters::Logger.new(logger: Rails.logger),
-    rollbar: ArcadiaLogger::Adapters::Rollbar.new # needs to be already configured (api key set) in your app
+    rollbar: ArcadiaLogger::Adapters::Rollbar.new, # needs to be already configured (api key set) in your app
+    logstash: ArcadiaLogger::Adapters::Logstash.new
   }
 end
 ```
@@ -43,6 +44,9 @@ ArcadiaLogger.error('message')
 
 # to selected adapters
 ArcadiaLogger.error('message', adapters: [:custom_logger, :rollbar])
+
+# some adapters allow for options
+ArcadiaLogger.debug('message', adapters: [:logstash], options: { tags: ['TAG'] })
 
 ```
 

--- a/arcadia_logger.gemspec
+++ b/arcadia_logger.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rollbar', '~> 2.12' # TODO: making adapters separate gems would allow to remove dependency
+  spec.add_dependency 'logstash-logger', '~> 0.25'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/arcadia_logger.rb
+++ b/lib/arcadia_logger.rb
@@ -5,6 +5,7 @@ module ArcadiaLogger
   module Adapters
     autoload :Logger, 'arcadia_logger/adapters/logger'
     autoload :Rollbar, 'arcadia_logger/adapters/rollbar'
+    autoload :Logstash, 'arcadia_logger/adapters/logstash'
   end
 
   @@adapters = { logger: Adapters::Logger.new }
@@ -14,14 +15,14 @@ module ArcadiaLogger
       @@adapters = value
     end
 
-    def log(severity:, message:, adapters: @@adapters.keys)
+    def log(severity:, message:, adapters: @@adapters.keys, options: {})
       adapters.each do |adapter_id|
-        @@adapters[adapter_id].log(severity: severity, message: message)
+        @@adapters[adapter_id].log(severity: severity, message: message, options: options)
       end
     end
 
-    def method_missing(name, *args, adapters: @@adapters.keys)
-      log(severity: name, message: args.first, adapters: adapters)
+    def method_missing(name, *args, adapters: @@adapters.keys, options: {})
+      log(severity: name, message: args.first, adapters: adapters, options: options)
     end
 
     def warn(*args, adapters: @@adapters.keys)

--- a/lib/arcadia_logger/adapter.rb
+++ b/lib/arcadia_logger/adapter.rb
@@ -1,6 +1,6 @@
 module ArcadiaLogger
   class Adapter
-    def log(severity:, message:)
+    def log(severity:, message:, options: {})
     end
 
     def method_missing(name, *args)

--- a/lib/arcadia_logger/adapters/logger.rb
+++ b/lib/arcadia_logger/adapters/logger.rb
@@ -17,7 +17,7 @@ module ArcadiaLogger
         @logger = logger
       end
 
-      def log(severity:, message:)
+      def log(severity:, message:, options: {})
         @logger.log(SEVERITY[severity] || ::Logger::Severity::UNKNOWN, message.to_s)
       end
     end

--- a/lib/arcadia_logger/adapters/logstash.rb
+++ b/lib/arcadia_logger/adapters/logstash.rb
@@ -1,0 +1,22 @@
+require 'logstash-logger'
+
+module ArcadiaLogger
+  module Adapters
+    class Logstash < ArcadiaLogger::Adapter
+      def initialize
+        # URI scheme for LOGSTASH_URI: "#{type}://#{host}:#{port}/#{path}"
+        # Defaults to UDP on 0.0.0.0 -> "udp://0.0.0.0:5228"
+        @logger = ::LogStashLogger.new(uri: ENV['LOGSTASH_URI'], sync: true)
+      end
+
+      # ArcadiaLogger.log(severity: :debug, message: { test: "testing" }, options: { tags: ["test"] })
+      def log(severity:, message:, options: {})
+        if options[:tags]
+          @logger.tagged(options[:tags]) { @logger.send(severity, message: message) }
+        else
+          @logger.send(severity, message: message)
+        end
+      end
+    end
+  end
+end

--- a/lib/arcadia_logger/adapters/rollbar.rb
+++ b/lib/arcadia_logger/adapters/rollbar.rb
@@ -7,7 +7,7 @@ module ArcadiaLogger
         @logger = ::Rollbar
       end
 
-      def log(severity:, message:)
+      def log(severity:, message:, options: {})
         @logger.log(severity, message)
       end
     end

--- a/spec/arcadia_logger_spec.rb
+++ b/spec/arcadia_logger_spec.rb
@@ -13,21 +13,21 @@ RSpec.describe ArcadiaLogger do
     end
 
     it 'logs to all adapters by default' do
-      expect(adapter1).to receive(:log).with(severity: :info, message: 'message')
-      expect(adapter2).to receive(:log).with(severity: :info, message: 'message')
+      expect(adapter1).to receive(:log).with(severity: :info, message: 'message', options: {})
+      expect(adapter2).to receive(:log).with(severity: :info, message: 'message', options: {})
       ArcadiaLogger.log(severity: :info, message: 'message')
     end
 
     it 'logs to selected adapters' do
       expect(adapter1).not_to receive(:log)
-      expect(adapter2).to receive(:log).with(severity: :info, message: 'message')
+      expect(adapter2).to receive(:log).with(severity: :info, message: 'message', options: {})
       ArcadiaLogger.log(severity: :info, message: 'message', adapters: [:adapter2])
     end
 
     context 'logger style methods' do
       %i[debug info warn error fatal].each do |severity|
         it "logs with #{severity} severity" do
-          expect(adapter1).to receive(:log).with(severity: severity, message: severity.to_s)
+          expect(adapter1).to receive(:log).with(severity: severity, message: severity.to_s, options: {})
           ArcadiaLogger.send(severity, severity.to_s, adapters: [:adapter1])
         end
       end


### PR DESCRIPTION
This extends the current ArcadiaLogger to support Logstash. Currently only using this for logging scraper activity. Requires `ENV['LOGSTASH_URI']` to be set in apps that use it.

Currently uses [logstash-logger](https://github.com/dwbutler/logstash-logger) gem and the `sync: true` option which bypasses the buffer (was having trouble doing non-sync).